### PR TITLE
feat: sort at-rules above other rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,45 +1,48 @@
 module.exports = {
-    "plugins": [
-        "stylelint-order"
+  plugins: ["stylelint-order"],
+  extends: "stylelint-config-standard",
+  rules: {
+    indentation: 4,
+    "at-rule-blacklist": [],
+    "at-rule-no-unknown": [true, { ignoreAtRules: ["/.*/"] }],
+    "string-quotes": "double",
+    "no-duplicate-selectors": true,
+    "color-hex-case": "lower",
+    "color-hex-length": "short",
+    "color-named": "never",
+    "selector-no-qualifying-type": true,
+    "selector-max-id": 0,
+    "selector-combinator-space-after": "always",
+    "selector-attribute-quotes": "always",
+    "selector-attribute-operator-space-before": "never",
+    "selector-attribute-operator-space-after": "never",
+    "selector-attribute-brackets-space-inside": "never",
+    "declaration-block-trailing-semicolon": "always",
+    "declaration-no-important": true,
+    "declaration-colon-space-before": "never",
+    "declaration-colon-space-after": "always",
+    "number-leading-zero": "always",
+    "function-url-quotes": "always",
+    "font-weight-notation": "numeric",
+    "font-family-name-quotes": "always-unless-keyword",
+    "comment-whitespace-inside": "always",
+    "rule-empty-line-before": [
+      "always",
+      {
+        except: ["first-nested"]
+      }
     ],
-    "extends": "stylelint-config-standard", 
-    "rules": {
-        "indentation": 4,
-        "at-rule-blacklist": [],
-        "at-rule-no-unknown": [true, { ignoreAtRules: ["/.*/"] }],
-        "string-quotes": "double",
-        "no-duplicate-selectors": true,
-        "color-hex-case": "lower",
-        "color-hex-length": "short",
-        "color-named": "never",
-        "selector-no-qualifying-type": true,
-        "selector-max-id": 0,
-        "selector-combinator-space-after": "always",
-        "selector-attribute-quotes": "always",
-        "selector-attribute-operator-space-before": "never",
-        "selector-attribute-operator-space-after": "never",
-        "selector-attribute-brackets-space-inside": "never",
-        "declaration-block-trailing-semicolon": "always",
-        "declaration-no-important": true,
-        "declaration-colon-space-before": "never",
-        "declaration-colon-space-after": "always",
-        "number-leading-zero": "always",
-        "function-url-quotes": "always",
-        "font-weight-notation": "numeric",
-        "font-family-name-quotes": "always-unless-keyword",
-        "comment-whitespace-inside": "always",
-        "rule-empty-line-before": ["always", {
-            except: [
-                "first-nested"
-            ]
-        }],
-        "selector-pseudo-element-colon-notation": "double",
-        "media-feature-parentheses-space-inside": "never",
-        "media-feature-colon-space-before": "never",
-        "media-feature-colon-space-after": "always",
-        "order/properties-alphabetical-order": true,
-        "declaration-block-no-redundant-longhand-properties": null,
-        "block-no-empty": [true, { "severity": "warning" }],
-        "shorthand-property-no-redundant-values": null
-    }
-}
+    "selector-pseudo-element-colon-notation": "double",
+    "media-feature-parentheses-space-inside": "never",
+    "media-feature-colon-space-before": "never",
+    "media-feature-colon-space-after": "always",
+    "order/properties-alphabetical-order": true,
+    "order/order": [
+      ["at-rules"],
+      { unspecified: "bottom", severity: "warning" }
+    ],
+    "declaration-block-no-redundant-longhand-properties": null,
+    "block-no-empty": [true, { severity: "warning" }],
+    "shorthand-property-no-redundant-values": null
+  }
+};


### PR DESCRIPTION
This change would sort `@` properties above all other properties. Properties would then be alphabetically ordered after that. For example:

```
.parent{
    background: #f00;
    margin: 2px;
    color: #0f0;
    @include test-mixin();

    .nested {
        padding: 20px;
        @include test-mixin2();
        color: #00f;
    }
}
```
is reformatted to this:
```
.parent {
    @include test-mixin();

    background: #f00;
    color: #0f0;
    margin: 2px;

    .nested {
        @include test-mixin2();

        color: #00f;
        padding: 20px;
    }
}
```

Thoughts? @slkennedy @Keale2 